### PR TITLE
Add support for plugins and raw source

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ var resin = require('topcoat-resin');
     resin({
         // Pass it a css file to process
         src: 'src/entry.css',
+        // Alternatively pass it the file contents, defaults to src
+        contents: 'body { color: rgba(#fff, 0.5); }',
         // Tell it what browsers to prefix for
         browsers: ['last 1 version', 'ios', 'android 4'],
         // Add a namespace to your classes to avoid collisions
@@ -31,7 +33,9 @@ var resin = require('topcoat-resin');
         // Add a license to the final output
         license: '// Copyright 2013 and stuff \n',
         // Generate sourecemaps for debugging
-        debug: true
+        debug: true,
+        // Extend resin further with more rework plugins
+        use: [rework.ease()]
     });
 
 ```
@@ -80,6 +84,7 @@ Resin supports:
 * [Namespacing](https://github.com/kristoferjoseph/rework-namespace)
 * [Autoprefixer](https://github.com/ai/autoprefixer)
 * License addition
+* Adding more rework plugins
 * Source maps for debugging
 
 TODO

--- a/test/resin.test.js
+++ b/test/resin.test.js
@@ -1,4 +1,5 @@
 var resin = require('..'),
+    rework = require('rework'),
     assert = require('assert'),
     read = require('fs').readFileSync,
     write = require('fs').writeFileSync;
@@ -13,17 +14,41 @@ describe('resin', function() {
             license: read('test/fixtures/license.txt'),
             url: 'img/'
         }),
-            expected = read('test/expected/resin.expected.css', 'utf-8').toString().trim();
+        expected = read('test/expected/resin.expected.css', 'utf-8').toString().trim();
 
         assert.equal(actual, expected, 'Generated output should match expected file');
     });
 
-    it('should throw error when no input file is supplied', function() {
+    it('should throw error when no input file or contents are supplied', function() {
         assert.throws(function() {
             resin({
                 src: ''
             });
         }, Error);
+    });
+
+    it('should allow passing raw contents instead of a file src', function() {
+        var actual = resin({
+            contents: read('test/fixtures/resin.test.css', 'utf-8').toString().trim(),
+            namespace: 'topcoat',
+            license: read('test/fixtures/license.txt'),
+            url: 'img/'
+        }),
+        expected = read('test/expected/resin.expected.css', 'utf-8').toString().trim();
+
+        assert.equal(actual, expected, 'Generated output should match expected file');
+    });
+
+    it('should allow adding additional rework plugins', function() {
+        var prefix = '#dat-prefix',
+            input = '.test {\n  color: #C0FFEE;\n}',
+            actual = resin({
+            contents: input,
+            use: [rework.prefixSelectors(prefix)]
+        }),
+        expected = prefix + ' ' + input;
+
+        assert.equal(actual, expected, 'Generated output should match expected file');
     });
 
     it('should not fail when passed a debug flag', function() {


### PR DESCRIPTION
This adds support and tests for the following two features I thought others might like:
- Passing a string to resin, instead of a file location.
- Adding additional rework plugins on top of Resin.
